### PR TITLE
Fixed Right Clicking Ammo Bags Causing Shotgun Shots

### DIFF
--- a/entities/weapons/weapon_hdn_ammobox/shared.lua
+++ b/entities/weapons/weapon_hdn_ammobox/shared.lua
@@ -48,3 +48,7 @@ function SWEP:PrimaryAttack()
 		end
 	end 
 end
+
+function SWEP:SecondaryAttack()
+	return true
+end


### PR DESCRIPTION
If you were to right click with Ammo Bags it would shoot like a shotgun, can someone confirm to make sure it wasn't something only on my end? It's a weird ass bug but this fixed it.